### PR TITLE
use native_targets instead of all targets to avoid crash

### DIFF
--- a/lib/pod/command/deintegrate.rb
+++ b/lib/pod/command/deintegrate.rb
@@ -55,9 +55,15 @@ module Pod
       end
 
     private
+    
+      def native_targets(project)
+        project.targets.reject do |target|
+          target.is_a? Xcodeproj::Project::Object::PBXAggregateTarget
+        end
+      end
 
       def deintegrate_project(project)
-        project.targets.each do |target|
+        native_targets(project).each do |target|
           UI.section("Deintegrating target #{target.name}") do
             deintegrate_target(target)
           end


### PR DESCRIPTION
code is based on:
https://github.com/CocoaPods/CocoaPods/commit/109af82eae4c477d8800ae8d5643a84f75c65963
https://github.com/CocoaPods/CocoaPods/issues/729

without it, 'pod deintegrate' will crash on some projects with the error:

```
NoMethodError - undefined method `frameworks_build_phase' for #<Xcodeproj::Project::Object::PBXAggregateTarget:0x007fe7c8890f50>
/Library/Ruby/Gems/2.0.0/gems/cocoapods-deintegrate-0.1.1/lib/pod/command/deintegrate.rb:109:in `deintegrate_pods_libraries'
```

probably because it's trying to deintegrate an aggregated target that doesn't have the 'frameworks_build_phase' method.